### PR TITLE
Use a default event name for intercom events

### DIFF
--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -43,7 +43,7 @@ export default class Intercom extends BaseAdapter {
 
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
-    const { event } = compactedOptions;
+    const { event = 'unspecified-event' } = compactedOptions;
     const props = without(compactedOptions, 'event');
 
     window.Intercom('trackEvent', event, props);

--- a/tests/unit/metrics-adapters/intercom-test.js
+++ b/tests/unit/metrics-adapters/intercom-test.js
@@ -95,8 +95,13 @@ module('intercom adapter', function(hooks) {
     adapter.trackEvent({
       event: 'Ate a cookie'
     });
+    adapter.trackEvent({
+      event: null,
+      id: 'hY7gQr0'
+    })
     assert.ok(stub.firstCall.calledWith('trackEvent', 'Video played', { videoLength: 213, id: 'hY7gQr0' }), 'it sends the correct arguments');
     assert.ok(stub.secondCall.calledWith('trackEvent', 'Ate a cookie'), 'it sends the correct arguments');
+    assert.ok(stub.thirdCall.calledWith('trackEvent', 'unspecified-event', { id: 'hY7gQr0'}), 'it sends the correct arguments');
   });
 
   test('#trackPage calls `Intercom()` with the right arguments', function(assert) {


### PR DESCRIPTION
To honor the documentation it should be enough to supply an app-id for intercom usage. However, if the event name is omitted an error occurs as Intercom requires an event-name. By setting a default event called "unspecified-event" this problem is circumvented.